### PR TITLE
Update sibench.py

### DIFF
--- a/benchmaster/sibench.py
+++ b/benchmaster/sibench.py
@@ -30,7 +30,7 @@ def run(spec):
 
     # From here on we should be good, so let's build our command line to invoke sibench
 
-    cmd = '{} {} run -s{} -c{} -x{} -r{} -u{} -d{} -w{} -b{} -osibench.json --servers {} -p {}'.format(
+    cmd = '{} {} run -s{} -c{} -x{} -r{} -u{} -d{} -w{} -b{} --servers {} -p {}'.format(
             sibench_binary,
             protocol,
             spec.object_size,


### PR DESCRIPTION
Removed the "-osibench.json" argument from sibench.  Most people don't use it, and it's much faster without it for large runs.