### PR TITLE
Latency was in 10^-6 seconds, we want 10^-3 seconds (milliseconds)

### DIFF
--- a/benchmaster/sibench.py
+++ b/benchmaster/sibench.py
@@ -123,11 +123,11 @@ def _direction_result(analysis):
     # Bandwidth is in B/s, but we want MB/s
     bandwidth = analysis['BandwidthBytes'] / (1024 * 1024)
 
-    # Response times are in ns, but we want ms
-    res_min = analysis['ResTimeMin'] / (1000 * 1000)
-    res_max = analysis['ResTimeMax'] / (1000 * 1000)
-    res_95 = analysis['ResTime95'] / (1000 * 1000)
-    res_avg = analysis['ResTimeAvg'] / (1000 * 1000)
+    # Response times are in microseconds, but we want milliseconds
+    res_min = analysis['ResTimeMin'] / 1000
+    res_max = analysis['ResTimeMax'] / 1000
+    res_95 = analysis['ResTime95'] / 1000
+    res_avg = analysis['ResTimeAvg'] / 1000
 
     successes = analysis['Successes']
     failures = analysis['Failures']


### PR DESCRIPTION
Numbers in the spreadsheet appear as fractions of a millisecond whereas they are clearly shown as hundreds of milliseconds in the CLI and JSON files. The assumption appears to be that the data was in nanoseconds (10^-9) but it was actually in microseconds (10^-6) which meant an incorrect conversion into ms.